### PR TITLE
Add multiFilter function to enable filtering of multiple types of data

### DIFF
--- a/dist/firebaseDataProvider.js
+++ b/dist/firebaseDataProvider.js
@@ -52,7 +52,30 @@ var react_admin_1 = require("react-admin");
 var rxjs_1 = require("rxjs");
 // UTILS
 function isEmptyObj(obj) {
-    return JSON.stringify(obj) == '{}';
+    return JSON.stringify(obj) == "{}";
+}
+/**
+ * Filters an array of objects with multiple criteria.
+ *
+ * @param  {Array}  array: the array to filter
+ * @param  {Object} filters: an object with the filter criteria as the property names
+ * @return {Array}
+ */
+function multiFilter(array, filters) {
+    var filterKeys = Object.keys(filters);
+    // filters all elements passing the criteria
+    return array.filter(function (item) {
+        // dynamically validate all filter criteria
+        return filterKeys.every(function (key) {
+            if (!Array.isArray(filters[key])) {
+                filters[key] = [filters[key]];
+            }
+            // ignores an empty filter
+            if (!filters[key].length)
+                return true;
+            return filters[key].includes(item[key]);
+        });
+    });
 }
 var FirebaseClient = /** @class */ (function () {
     function FirebaseClient(firebaseConfig) {
@@ -113,11 +136,11 @@ var FirebaseClient = /** @class */ (function () {
                         data = r.list;
                         if (params.sort != null) {
                             _a = params.sort, field = _a.field, order = _a.order;
-                            if (order === 'ASC') {
-                                this.sortArray(data, field, 'asc');
+                            if (order === "ASC") {
+                                this.sortArray(data, field, "asc");
                             }
                             else {
-                                this.sortArray(data, field, 'desc');
+                                this.sortArray(data, field, "desc");
                             }
                         }
                         filteredData = this.filterArray(data, params.filter);
@@ -143,7 +166,7 @@ var FirebaseClient = /** @class */ (function () {
                         r = _a.sent();
                         data = r.list.filter(function (val) { return val.id === params.id; });
                         if (data.length < 1) {
-                            throw Error('react-admin-firebase: No id found matching: ' + params.id);
+                            throw Error("react-admin-firebase: No id found matching: " + params.id);
                         }
                         return [2 /*return*/, { data: data[0] }];
                 }
@@ -258,7 +281,7 @@ var FirebaseClient = /** @class */ (function () {
                     case 1:
                         r = _a.sent();
                         ids = new Set(params.ids);
-                        matches = r.list.filter(function (item) { return ids.has(item['id']); });
+                        matches = r.list.filter(function (item) { return ids.has(item["id"]); });
                         return [2 /*return*/, {
                                 data: matches
                             }];
@@ -280,11 +303,11 @@ var FirebaseClient = /** @class */ (function () {
                         matches = data.filter(function (val) { return val[targetField] === targetValue; });
                         if (params.sort != null) {
                             _a = params.sort, field = _a.field, order = _a.order;
-                            if (order === 'ASC') {
-                                this.sortArray(data, field, 'asc');
+                            if (order === "ASC") {
+                                this.sortArray(data, field, "asc");
                             }
                             else {
-                                this.sortArray(data, field, 'desc');
+                                this.sortArray(data, field, "desc");
                             }
                         }
                         pageStart = (params.pagination.page - 1) * params.pagination.perPage;
@@ -301,38 +324,28 @@ var FirebaseClient = /** @class */ (function () {
             return val.path === resourceName;
         });
         if (matches.length < 1) {
-            throw new Error('react-admin-firebase: Cant find resource with id');
+            throw new Error("react-admin-firebase: Cant find resource with id");
         }
         var match = matches[0];
         return match;
     };
     FirebaseClient.prototype.sortArray = function (data, field, dir) {
         data.sort(function (a, b) {
-            var aValue = a[field] ? a[field].toString().toLowerCase() : '';
-            var bValue = b[field] ? b[field].toString().toLowerCase() : '';
+            var aValue = a[field] ? a[field].toString().toLowerCase() : "";
+            var bValue = b[field] ? b[field].toString().toLowerCase() : "";
             if (aValue > bValue) {
-                return dir === 'asc' ? -1 : 1;
+                return dir === "asc" ? -1 : 1;
             }
             if (aValue < bValue) {
-                return dir === 'asc' ? 1 : -1;
+                return dir === "asc" ? 1 : -1;
             }
             return 0;
         });
     };
     FirebaseClient.prototype.filterArray = function (data, filterFields) {
-        if (isEmptyObj(filterFields)) {
+        if (isEmptyObj(filterFields))
             return data;
-        }
-        var fieldNames = Object.keys(filterFields);
-        return data.filter(function (item) { return fieldNames.reduce(function (previousMatched, fieldName) {
-            var fieldSearchText = filterFields[fieldName].toLowerCase();
-            var dataFieldValue = item[fieldName];
-            if (dataFieldValue == null) {
-                return false;
-            }
-            var currentIsMatched = dataFieldValue.toLowerCase().includes(fieldSearchText);
-            return previousMatched || currentIsMatched;
-        }, false); });
+        return multiFilter(data, filterFields);
     };
     FirebaseClient.prototype.setList = function (newList, resourceName) {
         return this.tryGetResource(resourceName).then(function (resource) {
@@ -347,7 +360,7 @@ var FirebaseClient = /** @class */ (function () {
                     return val.path === resourceName;
                 });
                 if (matches.length < 1) {
-                    throw new Error('react-admin-firebase: Cant find resource with id');
+                    throw new Error("react-admin-firebase: Cant find resource with id");
                 }
                 match = matches[0];
                 return [2 /*return*/, match];

--- a/src/firebaseDataProvider.ts
+++ b/src/firebaseDataProvider.ts
@@ -1,5 +1,5 @@
-import * as firebase from 'firebase/app';
-import 'firebase/firestore';
+import * as firebase from "firebase/app";
+import "firebase/firestore";
 
 import {
   CREATE,
@@ -11,8 +11,9 @@ import {
   GET_ONE,
   UPDATE,
   UPDATE_MANY
-} from 'react-admin';
-import { Observable, Subject } from 'rxjs';
+} from "react-admin";
+import { Observable, Subject } from "rxjs";
+import { type } from "os";
 
 export interface IResource {
   path: string;
@@ -24,7 +25,34 @@ export interface IResource {
 // UTILS
 
 function isEmptyObj(obj) {
-  return JSON.stringify(obj) == '{}';
+  return JSON.stringify(obj) == "{}";
+}
+
+/**
+ * Filters an array of objects with multiple criteria.
+ *
+ * @param  {Array}  array: the array to filter
+ * @param  {Object} filters: an object with the filter criteria as the property names
+ * @return {Array}
+ */
+function multiFilter(
+  array: Array<{}>,
+  filters: { [field: string]: any }
+): Array<{}> {
+  const filterKeys = Object.keys(filters);
+
+  // filters all elements passing the criteria
+  return array.filter(item => {
+    // dynamically validate all filter criteria
+    return filterKeys.every(key => {
+      if (!Array.isArray(filters[key])) {
+        filters[key] = [filters[key]];
+      }
+      // ignores an empty filter
+      if (!filters[key].length) return true;
+      return filters[key].includes(item[key]);
+    });
+  });
 }
 
 class FirebaseClient {
@@ -86,10 +114,10 @@ class FirebaseClient {
     const data = r.list;
     if (params.sort != null) {
       const { field, order } = params.sort;
-      if (order === 'ASC') {
-        this.sortArray(data, field, 'asc');
+      if (order === "ASC") {
+        this.sortArray(data, field, "asc");
       } else {
-        this.sortArray(data, field, 'desc');
+        this.sortArray(data, field, "desc");
       }
     }
     let filteredData = this.filterArray(data, params.filter);
@@ -110,7 +138,7 @@ class FirebaseClient {
     const r = await this.tryGetResource(resourceName);
     const data = r.list.filter((val: { id: string }) => val.id === params.id);
     if (data.length < 1) {
-      throw Error('react-admin-firebase: No id found matching: ' + params.id);
+      throw Error("react-admin-firebase: No id found matching: " + params.id);
     }
     return { data: data[0] };
   }
@@ -197,7 +225,7 @@ class FirebaseClient {
   ): Promise<IResponseGetMany> {
     const r = await this.tryGetResource(resourceName);
     const ids = new Set(params.ids);
-    const matches = r.list.filter(item => ids.has(item['id']));
+    const matches = r.list.filter(item => ids.has(item["id"]));
     return {
       data: matches
     };
@@ -214,10 +242,10 @@ class FirebaseClient {
     const matches = data.filter(val => val[targetField] === targetValue);
     if (params.sort != null) {
       const { field, order } = params.sort;
-      if (order === 'ASC') {
-        this.sortArray(data, field, 'asc');
+      if (order === "ASC") {
+        this.sortArray(data, field, "asc");
       } else {
-        this.sortArray(data, field, 'desc');
+        this.sortArray(data, field, "desc");
       }
     }
     const pageStart = (params.pagination.page - 1) * params.pagination.perPage;
@@ -232,40 +260,29 @@ class FirebaseClient {
       return val.path === resourceName;
     });
     if (matches.length < 1) {
-      throw new Error('react-admin-firebase: Cant find resource with id');
+      throw new Error("react-admin-firebase: Cant find resource with id");
     }
     const match: IResource = matches[0];
     return match;
   }
 
-  private sortArray(data: Array<{}>, field: string, dir: 'asc' | 'desc') {
+  private sortArray(data: Array<{}>, field: string, dir: "asc" | "desc") {
     data.sort((a: {}, b: {}) => {
-      const aValue = a[field] ? a[field].toString().toLowerCase() : '';
-      const bValue = b[field] ? b[field].toString().toLowerCase() : '';
+      const aValue = a[field] ? a[field].toString().toLowerCase() : "";
+      const bValue = b[field] ? b[field].toString().toLowerCase() : "";
       if (aValue > bValue) {
-        return dir === 'asc' ? -1 : 1;
+        return dir === "asc" ? -1 : 1;
       }
       if (aValue < bValue) {
-        return dir === 'asc' ? 1 : -1;
+        return dir === "asc" ? 1 : -1;
       }
       return 0;
     });
   }
 
-  private filterArray(data: Array<{}>, filterFields: { [field: string]: string }) {
-    if (isEmptyObj(filterFields)) {
-      return data;
-    }
-    const fieldNames = Object.keys(filterFields);
-    return data.filter(item => fieldNames.reduce((previousMatched, fieldName) => {
-      const fieldSearchText = filterFields[fieldName].toLowerCase();
-      const dataFieldValue = item[fieldName];
-      if (dataFieldValue == null) {
-        return false;
-      }
-      const currentIsMatched = dataFieldValue.toLowerCase().includes(fieldSearchText);
-      return previousMatched || currentIsMatched;
-    }, false));
+  private filterArray(data: Array<{}>, filterFields: { [field: string]: any }) {
+    if (isEmptyObj(filterFields)) return data;
+    return multiFilter(data, filterFields);
   }
 
   private setList(newList: Array<{}>, resourceName: string): Promise<any> {
@@ -279,7 +296,7 @@ class FirebaseClient {
       return val.path === resourceName;
     });
     if (matches.length < 1) {
-      throw new Error('react-admin-firebase: Cant find resource with id');
+      throw new Error("react-admin-firebase: Cant find resource with id");
     }
     const match: IResource = matches[0];
     return match;


### PR DESCRIPTION
In this commit I added a new function called `multiFilter` that enables the `filterArray` function to accept different types of data. This fixes a previous bug in the firebaseDataProvider which causes it to crash when something different from a `string` value is passed as a filter parameter.

The function `multiFilter`, which I slightly modified, is based on this code: https://gist.github.com/jherax/f11d669ba286f21b7a2dcff69621eb72
